### PR TITLE
计算SINR阈值等

### DIFF
--- a/MatFilesUtility5G/findRBsBeaconSINRmin_5G.m
+++ b/MatFilesUtility5G/findRBsBeaconSINRmin_5G.m
@@ -70,9 +70,9 @@ end
 % the second option uses the actual code rate
 % the third option evaluates the code rate by only considering the RB
 % necessary for the transmission instead of the whole subchannel(s)
-%CR = TBS/(nRE*Qm);
-%CR = R;
-CR = TBSmin/(nREmin*Qm);
+CR = TBS/(nRE*Qm);
+% CR = R;
+% CR = TBSmin/(nREmin*Qm);
 
 % Compute spectral efficiency (bits/s·Hz)
 % Tslot in s
@@ -80,9 +80,18 @@ CR = TBSmin/(nREmin*Qm);
 
 NbitsHz = (12*14*Qm*CR)/(phyParams.Tslot_NR*phyParams.RBbandwidth);
 
-% Compute the minimum required SINR
-% (alfa is taken from 3GPP)
-alfa = 0.4;
-gammaMin_dB = pow2db(2^(NbitsHz/alfa)-1);
+%% Compute the minimum required SINR
+% Find minimum SINR for LTE-V2X automaticly, only for 10 MHz now 
+%  related method could be found in paper:
+%  Wu Z, Bartoletti S, Martinez V, Bazzi A. A Methodology for Abstracting 
+%  the Physical Layer of Direct V2X Communications Technologies. Sensors. 2022;
+%  22(23):9330. https://doi.org/10.3390/s22239330
+effective_throughput = packetSizeBits * (phyParams.RBsFrequency / RBsBeacon) /...
+    (phyParams.BwMHz * 1e6) / phyParams.Tslot_NR;
+
+shannon_throughput = effective_throughput / constants.IMPLEMENTLOSS_CV2X;
+sinr_linear = 2^(shannon_throughput)-1;
+gammaMin_dB = pow2db(sinr_linear);
+
 
 end

--- a/Simulation_get_pck_status.m
+++ b/Simulation_get_pck_status.m
@@ -7,9 +7,9 @@ clc          % Clear the command window
 
 
 %% 部分设置
-packetSize=350;                     % packet size [KB]
+packetSize=200;                     % packet size [KB]
 BandMHz = 10;                       % [MHz]
-rho = 0.1;                          % density [vehs/m]
+rho = 0.2;                          % density [vehs/m]
 rho_km = rho * 1000;                % density [vehs/km]
 speed=(43.14-197.5*rho) * 3.6;      % Average speed [km/h]
 speedStDev= speed/10;               % Standard deviation speed [km/h]

--- a/cal_mcs_related_characteristics.m
+++ b/cal_mcs_related_characteristics.m
@@ -1,0 +1,51 @@
+%% Calculate Coding Rate, Data Rate, and SINR of NR-V2X
+% with given MCS, packet size, and other parameters
+
+% init
+clear;clc;
+
+fullPath = fileparts(mfilename('fullpath'));
+addpath(genpath(fullPath));
+
+% parameters of NR-V2X
+phyParams.BwMHz = 10;               % [MHz]
+phyParams.sizeSubchannel = 12;      % number of RBs in each subchannel
+phyParams.SCS_NR = 30;              % Sets the SCS for 5G (kHz)
+phyParams.nDMRS_NR = 18;            % Sets the number of DMRS resource element used in each slot
+phyParams.SCIsymbols = 3;           % Sets the number of symbols dedicated to the SCI-1 between 2 and 3
+phyParams.nRB_SCI = 12;             % Sets the number of RBs dedicated to the SCI-1
+
+% Call function to find the total number of RBs in the frequency domain per Tslot in 5G
+phyParams.RBsFrequency = RBtable_5G(phyParams.BwMHz,phyParams.SCS_NR);
+
+phyParams.Tslot_NR = 1e-3/(phyParams.SCS_NR/15);            % 5G Tslot [s]
+phyParams.RBbandwidth = 180e3*phyParams.SCS_NR/15;          % 5G Resource Block Bandwidth [Hz]
+
+for packetSize = [200, 1600]        % packet size [bytes]
+    packetSizeBits = packetSize * 8;    % packet size [bits]
+    % print column name
+    fprintf("===========================================\n");
+    fprintf("%d bytes\n", packetSize);
+    fprintf("===========================================\n");
+    fprintf("iMCS\tCR\t\tDR [Mbps]\tnRB_b\tSINR_th[dB]\n");
+    % print
+    for MCS_NR = 0:28
+        phyParams.MCS_NR = MCS_NR;
+        try
+            % calculate
+            % NbitsHz [bits/s/Hz]
+            [nSubchannelperChannel,subchannelperPacket,nRB_b,gammaMin_dB,NbitsHz,CR,Qm] = findRBsBeaconSINRmin_5G(phyParams,packetSizeBits);
+            
+            % calculate data rate: 
+            % eq 4 in V. Todisco et al.: Performance Analysis of Sidelink 5G-V2X Mode 2 Through Open-Source Simulator
+            n_symslot = 12;         % the 1st and the last symbols are not used
+            n_scpPRB = 12;          % the number of subcarriers in the frequency domain per PRB
+            b_symbol_m = Qm;        % number of bits per symbol
+            DR = NbitsHz * phyParams.BwMHz;  % [Mbps]
+            
+            fprintf("%d\t\t%.2f\t%.2f\t\t%d\t\t%.2f\n", MCS_NR, CR, DR, nRB_b, gammaMin_dB);
+        catch exception
+            
+        end
+    end
+end

--- a/readResults.m
+++ b/readResults.m
@@ -1,0 +1,24 @@
+% read packet status data
+
+% get database path
+dbFilePath = fullfile(fileparts(mfilename('fullpath')), "Output", "NRV2X", "rho100_v_km", "resuts_1.db");
+tableName = 'PacketStatusDetail';
+% table fields
+% [time, TxID, RxID, BRID, distance, packet_status(1:correct, 0:error)]
+
+% link to the database
+conn = sqlite(dbFilePath,"readonly");
+
+% read data between 0 and 1 seconds
+startTime = 0;
+endTime = 0.1;
+
+% example1
+sqlquery = sprintf("select * from %s where time > %f and time < %f", tableName, startTime, endTime);
+partData1 = fetch(conn,sqlquery);
+
+% example2
+sqlquery = sprintf("select * from PacketStatusDetail where time < 0.1 and TxID = 206 and packet_status = 1");
+partData2 = fetch(conn, sqlquery);
+
+close(conn);


### PR DESCRIPTION
1、SINR阈值计算方法见Wu, Z., Bartoletti, S., Martinez, V., & Bazzi, A. (2022). A methodology for abstracting the physical layer of direct V2X communications technologies. Sensors, 22(23), 9330.

2、计算其他参数方法见Todisco, V., Bartoletti, S., Campolo, C., Molinaro, A., Berthet, A. O., & Bazzi, A. (2021). Performance analysis of sidelink 5G-V2X mode 2 through an open-source simulator. IEEE Access, 9, 145648-145661.

3、Data Rate 由文献2中公式4的结果乘以信道带宽得到